### PR TITLE
handle reconnect (opcode 7)

### DIFF
--- a/lib/wumpex/gateway.ex
+++ b/lib/wumpex/gateway.ex
@@ -247,6 +247,14 @@ defmodule Wumpex.Gateway do
     end
   end
 
+  # Handles RECONNECT
+  # https://discord.com/developers/docs/topics/opcodes-and-status-codes#opcodes-and-status-codes
+  def dispatch(%{op: 7}, state) do
+    send_frame(:close)
+
+    state
+  end
+
   # Handles READY event
   # https://discord.com/developers/docs/topics/gateway#ready
   def dispatch(


### PR DESCRIPTION
Handles the reconnect opcode sent by Discord.

This prevents crashing when Discord requests a reconnect.